### PR TITLE
Add more CLI options (#19)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "public-square/phpecc": "^0.1.0",
         "bitwasp/bech32": "^0.0.1",
         "simplito/elliptic-php": "^1.0",
-        "phrity/websocket": "^1.6"
+        "phrity/websocket": "^1.6",
+        "vanilla/garden-cli": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",

--- a/src/Application/Client.php
+++ b/src/Application/Client.php
@@ -8,6 +8,7 @@ use swentel\nostr\Event\Event;
 use swentel\nostr\Message\EventMessage;
 use swentel\nostr\Relay\Relay;
 use swentel\nostr\Sign\Sign;
+use Garden\Cli\Cli;
 
 class Client
 {
@@ -19,40 +20,40 @@ class Client
     public function run($args): void
     {
 
-        // This is a very basic start, we look for 6 keys in the incoming
-        // args which have to be, --content, --key, --relay. If found, we
+        // This is a very basic start, we look for several arguments in the incoming
+        // args which minimum have to be, --content, --key, --relay. If found, we
         // will send a text note to this relay.
 
-        $content = $socket = $private_key_file = '';
+        $content = $relay = $private_key_file = '';
 
-        if (count($args) !== 7) {
-            $this->showHelp('Missing arguments');
-            return;
-        }
+        // Define the cli options.
+        $cli = new Cli();
 
-        foreach ($args as $current_key => $value) {
-            switch ($value) {
-                case '--content':
-                    $array_key = $current_key + 1;
-                    $content = trim($args[$array_key]);
-                    break;
-                case '--relay':
-                    $array_key = $current_key + 1;
-                    $socket = trim($args[$array_key]);
-                    break;
-                case '--key':
-                    $array_key = $current_key + 1;
-                    $private_key_file = trim($args[$array_key]);
-                    break;
-            }
-        }
+        $cli->description('Send nostr events to relays')
+            ->opt('content:c', 'Content (Required)')
+            ->opt('key:p', 'Private key file location to use (Required).')
+            ->opt('relay:r', 'Relays to publish the events (Required).')
+            ->opt('kind:k', 'Event kinds (Optional, Default: 1).', false, 'integer')
+            ->opt('created-at:a', 'Event created_at in unixtime (Optional).', false, 'integer')
+            ->opt('tags:t', 'Comma separated tags (Optional). Example: t:nostr,t:travel,e:eventId', false);
+
+        // Parse and return cli args.
+        $parsedArgs = $cli->parse($args, true);
+
+        $kind = $parsedArgs->getOpt('kind', 1);
+        $createdAt = $parsedArgs->getOpt('created_at');
+        $content = $parsedArgs->getOpt('content');
+        $relay = $parsedArgs->getOpt('relay');
+        $private_key_file = $parsedArgs->getOpt('key', '');
+        $stringTags = $parsedArgs->getOpt('tags', '');
+        $tags = self::parseNostrTags($stringTags);
 
         if (empty($content)) {
             $this->showHelp('The content is empty');
             return;
         }
 
-        if (empty($socket)) {
+        if (empty($relay)) {
             $this->showHelp('The relay is empty');
             return;
         }
@@ -77,11 +78,14 @@ class Client
         // Basic validation done.
 
         $event = new Event();
-        $event->setContent($content)->setKind(1);
+        $event->setContent($content)->setKind($kind)->setTags($tags);
+
+        if (isset($createdAt)) $event->setCreatedAt($createdAt);
+
         $signer = new Sign();
         $signer->signEvent($event, $private_key);
         $eventMessage = new EventMessage($event);
-        $relay = new Relay($socket, $eventMessage);
+        $relay = new Relay($relay, $eventMessage);
         $result = $relay->send();
         if ($result->isSuccess()) {
             print "Send to Nostr!\n";
@@ -92,7 +96,44 @@ class Client
 
     protected function showHelp($message): void
     {
-        print "\n[error] " . $message . "\n\nUsage:\n";
-        print "nostr-php --content \"Hello world!\" --key /home/path/to/nostr-private.key --relay wss://nostr.pleb.network\n\n";
+        print "\n[error] " . $message . "\n\nUsage:\n\n";
+        print "To get complete help for commands:\n\nnostr-php --help\n\n";
+        print "Basic Usage:\n\nnostr-php --content \"Hello world!\" --key /home/path/to/nostr-private.key --relay wss://nostr.pleb.network\n\n";
+    }
+
+    /**
+     * parseNostrTags is a helper function for the CLI that parses a string of tags and returns an array of tag-value pairs.
+     *
+     * Example: If the input string is "t:nostr,t:food,e:eventId,p:pubkey", it will be parsed as [["t","nostr"], ["t","food"], ["e","eventId"], ["p","pubkey"]].
+     *
+     * @param string $stringTags A string of tags separated by commas.
+     * @return array An array containing the parsed tag-value pairs.
+     **/
+    public static function parseNostrTags(string $stringTags = ''): array
+    {
+        // Split the string of tags into an array using ',' as the delimiter
+        $tempTags = explode(',', trim($stringTags));
+
+        // Check if the $tempTags array is empty or false
+        if (empty($tempTags)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($tempTags as $value) {
+            // Split each tag-value pair into an array using ':' as the delimiter
+            $innerValue = explode(':', trim($value));
+
+            // Check if the $innerValue array is false or has less than 2 elements
+            if ($innerValue === false || count($innerValue) < 2) {
+                continue;
+            }
+
+            // Add the tag-value pair to the result array
+            $result[] = $innerValue;
+        }
+
+        // Return the final array of parsed tag-value pairs
+        return $result;
     }
 }


### PR DESCRIPTION
This PR will add more CLI options (#19 ) by introducing four new parameters: `--created-at, --kind, --tags, --help`. This PR also uses [vanilla/garden-cli](https://github.com/swentel/nostr-php/commit/a8a75994d70db5b45d920fbd6c6c071545e9a4db) as CLI dependency instead of implementing manual parsing of CLI arguments as shown in previous implementation. 

Previously, CLI tools `nostr-php` only supports `--content, --relay, --key` parameters.

`nostr-php --help` will give command outputs as follows:
```bash
usage: nostr-php [<options>]

Send nostr events to relays

OPTIONS
  --content, -c      Content (Required)
  --created-at, -a   Event created_at in unixtime (Optional).
  --help, -?         Display this help.
  --key, -p          Private key file location to use (Required).
  --kind, -k         Event kinds (Optional, Default: 1).
  --relay, -r        Relays to publish the events (Required).
  --tags, -t         Comma separated tags (Optional). Example:
                     t:nostr,t:travel,e:eventId
```

`nostr-php` command without any arguments will give outputs as follows:
```bash
[error] The content is empty

Usage:

To get complete help for commands:

nostr-php --help

Basic Usage:

nostr-php --content "Hello world!" --key /home/path/to/nostr-private.key --relay wss://nostr.pleb.network
```

Thank you.