### PR TITLE
bump libgmp requirement to avoid bug in 6.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "php": ">=8.1 <8.4",
     "ext-gmp": "*",
     "ext-xml": "*",
+    "lib-gmp": ">=6.2.1",
     "bitwasp/bech32": "^0.0.1",
     "phrity/websocket": "^3.0",
     "simplito/elliptic-php": "^1.0",


### PR DESCRIPTION
The reason I added a new `lib-gmp` section instead of setting a version in `ext-gmp` is because composer sees `ext-gmp` with the version of PHP you have installed, whereas `ext-lib` show the actual version of libgmp installed in the system.

```
$ composer info -p | grep gmp
ext-gmp                8.3.14   The gmp PHP extension
lib-gmp                6.2.1    The gmp library
```

Sanity check. Momentarily setting ext-lib to an unreleased version of libgmp yields this (correct) error:

```
$ composer install
No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires linked library lib-gmp >=6.5.0 but it has the wrong version installed or is missing from your system, make sure to load the extension providing it.
```