### PR TITLE
Fix gmp issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,6 @@ jobs:
           php-version: ${{ matrix.php-version }}
       - run: composer install
       - run: php vendor/bin/php-cs-fixer check -v
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
       - run: php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "bitwasp/bech32": "^0.0.1",
     "phrity/websocket": "^3.0",
     "simplito/elliptic-php": "^1.0",
-    "uma/phpecc": "^0.1.3"
+    "uma/phpecc": "^0.2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.51",


### PR DESCRIPTION
I've cut a new release of uma/phpecc with no instances of gmp_pow() based on [this comment](https://github.com/php/php-src/issues/16870#issuecomment-2506560656), this seems to fix the issue.

To get there this also required to fork fgrosse/phpasn1 and cut a new release for that project as well, also abandoned: https://github.com/fgrosse/PHPASN1/compare/master...1ma:PHPASN1:master

Bottom line PHP Schnorr cryptography is abandoned, unmaintained and borked. Everything should move to libsecp256k1.

Addenda: the new env var can be removed once php-cs-fixer starts supporting PHP 8.4.