### PR TITLE
Phase out public-square fork of phpecc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "ext-gmp": "*",
     "ext-xml": "*",
     "bitwasp/bech32": "^0.0.1",
+    "paragonie/ecc": "^2.4",
     "phrity/websocket": "^3.0",
-    "simplito/elliptic-php": "^1.0",
-    "uma/phpecc": "^0.2.0"
+    "simplito/elliptic-php": "^1.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.51",


### PR DESCRIPTION
@paragonie-security has graciously accepted to merge the existing `SchnorrSignature` class from public-square/phpecc into his well maintained fork of mdanter/ecc, and even went the extra mile of analyzing the code and fixing several side-channel timing attacks in it.

His changes even made me notice timing attacks in the secp256k1-nostr-php extension :melting_face: Which I'll be ironing out in the next hours.

We should switch to his fork of phpecc and tag a new security patch release of the project ASAP.

https://github.com/paragonie/phpecc/pull/30#issuecomment-2605375887
https://github.com/paragonie/phpecc/commit/66669a76873bd67753f29a7139cc1c254f6d2350
https://github.com/paragonie/phpecc/commit/fdba22a506492eb6e5fe38c501c0df61eaf0b54c